### PR TITLE
Add information about the slot_size_array argument

### DIFF
--- a/docs/source/QAList.md
+++ b/docs/source/QAList.md
@@ -138,21 +138,40 @@ Thirdly, run with `./huge_ctr --train ./your_config.json`
 
 ## 24. How to set workspace_size_per_gpu_in_mb and slot_size_array?
 
-As embeddings are model parallel in HugeCTR,
-`workspace_size_per_gpu_in_mb` is a reference number for HugeCTR to allocate GPU memory accordingly and not necessarily the exact number of features in your dataset. It is depending on vocabulary size per gpu, embedding vector size and optimizer type.
+As embeddings are model-parallel in HugeCTR,
+`workspace_size_per_gpu_in_mb` is a reference number for HugeCTR to allocate GPU memory accordingly and not necessarily the exact number of features in your dataset.
+The value to set depends on the vocabulary size per GPU, the embedding vector size, and the optimizer type.
 Refer to the embedding workspace calculator in the [tools](https://github.com/NVIDIA-Merlin/HugeCTR/tree/master/tools) directory of the HugeCTR repository on GitHub.
-Use the calculator to calculate the vocabulary size per GPU and workspace_size per GPU for different embedding types, embedding vector size and optimizer type.
+Use the calculator to calculate the vocabulary size per GPU and workspace_size per GPU for different embedding types, embedding vector size, and optimizer type.
 
 In practice, we usually set it larger than the real size because of the non-uniform distribution of the keys.
 
-`slot_size_array` has 2 usages. It can be used as a replacement for `workspace_size_per_gpu_in_mb` to avoid wasting memory caused by imbalance vocabulary size. And it can also be used as a reference to add offset for keys in different slot.
+`slot_size_array` has 2 usages.
+It can be used as a replacement for `workspace_size_per_gpu_in_mb` to avoid wasting memory that is caused by imbalanced vocabulary size.
+It can also be used as a reference to add an offset for keys in a different slot.
 
-The relation between embedding type, `workspace_size_per_gpu_in_mb` and `slot_size_array` is:
+When you specify `slot_size_array` to avoid wasting memory, set each value in the array to the maximum key value in each slot.
+Refer to the following equation:
 
-* For `DistributedSlotEmbedding`, `workspace_size_per_gpu_in_mb` is needed and `slot_size_array` is not needed. Each GPU will allocate the same amount of memory for embedding table usage.
-* For `LocalizedSlotSparseEmbeddingHash`, only one of `workspace_size_per_gpu_in_mb` and `slot_size_array` is needed. If users can provide the exact size for each slot, we recommend users to specify `slot_size_array`. It can help avoid wasting memory caused by imbalance vocabulary size. Or you can specify `workspace_size_per_gpu_in_mb` so each GPU will allocate the same amount of memory for embedding table usage. If you specify both `slot_size_array` and `workspace_size_per_gpu_in_mb`, HugeCTR will use `slot_size_array` for `LocalizedSlotSparseEmbeddingHash`.
-* For `LocalizedSlotSparseEmbeddingOneHot`, `slot_size_array` is needed. It is used for allocating memory and adding offset for each slot.
-* For `HybridSparseEmbedding`, both `workspace_size_per_gpu_in_mb` and `slot_size_array` is needed. `workspace_size_per_gpu_in_md` is used for allocating memory while `slot_size_array` is used for adding offset
+$slot\_size\_array[k] = \max\limits_i slot^k_i + 1$
+
+Refer to the following list for information about the relation between embedding type, the `workspace_size_per_gpu_in_mb` value, and the `slot_size_array` value:
+
+* For `DistributedSlotEmbedding`, specify a value for `workspace_size_per_gpu_in_mb`.
+The `slot_size_array` argument is not needed.
+Each GPU allocates the same amount of memory for the embedding table usage.
+
+* For `LocalizedSlotSparseEmbeddingHash`, specify only one of `workspace_size_per_gpu_in_mb` or `slot_size_array`.
+If you can provide the exact size for each slot, we recommend that you specify `slot_size_array`.
+The `slot_size_array` argument can help avoid wasting memory that is caused by an imbalanced vocabulary size.
+As an alternative, you can specify `workspace_size_per_gpu_in_mb` so that each GPU allocates the same amount of memory for the embedding table usage.
+If you specify both `slot_size_array` and `workspace_size_per_gpu_in_mb`, HugeCTR uses `slot_size_array` for `LocalizedSlotSparseEmbeddingHash`.
+
+* For `LocalizedSlotSparseEmbeddingOneHot`, you must specify `slot_size_array`.
+The `slot_size_array` argument is used for allocating memory and adding an offset for each slot.
+
+* For `HybridSparseEmbedding`, specify both `workspace_size_per_gpu_in_mb` and `slot_size_array`.
+The `workspace_size_per_gpu_in_md` argument is used for allocating memory while `slot_size_array` is used for adding an offset for the embedding table usage.
 
 ## 25. Is nvlink required in HugeCTR?
 

--- a/docs/source/api/hugectr_layer_book.md
+++ b/docs/source/api/hugectr_layer_book.md
@@ -52,21 +52,51 @@ hugectr.SparseEmbedding()
 `SparseEmbedding` specifies the parameters related to the sparse embedding layer. One or several `SparseEmbedding` layers should be added to the Model instance after `Input` and before `DenseLayer`.
 
 **Arguments**
-* `embedding_type`: The embedding type to be used. The supported types include `hugectr.Embedding_t.DistributedSlotSparseEmbeddingHash`, `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingHash` and `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingOneHot`. There is NO default value and it should be specified by users. For detail about different embedding types, please refer to [Embedding Types Detail](./hugectr_layer_book.md#embedding-types-detail).
+* `embedding_type`: The embedding type.
+Specify one of the following values:
+  * `hugectr.Embedding_t.DistributedSlotSparseEmbeddingHash`
+  * `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingHash`
+  * `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingOneHot`
 
-* `workspace_size_per_gpu_in_mb`: Integer, the workspace memory size in megabyte per GPU. This workspace memory must be big enough to hold all the embedding vocabulary and its corresponding optimizer state used during the training and evaluation. There is NO default value and it should be specified by users. To understand how to set this value, please refer to [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array).
+  For information about the different embedding types, see [Embedding Types Detail](./hugectr_layer_book.md#embedding-types-detail).
+  This argument does not have a default value.
+  You must specify a value.
 
-* `embedding_vec_size`: Integer, the embedding vector size. There is NO default value and it should be specified by users.
+* `workspace_size_per_gpu_in_mb`: Integer, the workspace memory size in megabyte per GPU.
+This workspace memory must be big enough to hold all the embedding vocabulary and its corresponding optimizer state that is used during the training and evaluation.
+To understand how to set this value, see [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array).
+This argument does not have a default value.
+You must specify a value.
 
-* `combiner`: String, the intra-slot reduction operation, currently `sum` or `mean` are supported. There is NO default value and it should be specified by users.
+* `embedding_vec_size`: Integer, the embedding vector size.
+This argument does not have a default value.
+You must specify a value.
 
-* `sparse_embedding_name`: String, the name of the sparse embedding tensor to be referenced by following layers. There is NO default value and it should be specified by users.
+* `combiner`: String, the intra-slot reduction operation.
+Specify `sum` or `mean`.
+This argument does not have a default value.
+You must specify a value.
 
-* `bottom_name`: String, the number of the bottom tensor to be consumed by this sparse embedding layer. Please note that it should be a predefined sparse input name. There is NO default value and it should be specified by users.
+* `sparse_embedding_name`: String, the name of the sparse embedding tensor.
+This name is referenced by the following layers.
+This argument does not have a default value.
+You must specify a value.
 
-* `slot_size_array`: List[int], the cardinality array of input features. It should be consistent with that of the sparse input. This parameter is used in `LocalizedSlotSparseEmbeddingHash` and `LocalizedSlotSparseEmbeddingOneHot`, which can help avoid wasting memory caused by imbalance vocabulary size. Please refer [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array). There is NO default value and it should be specified by users.
+* `bottom_name`: String, the number of the bottom tensor to consume with this sparse embedding layer.
+Please note that the value should be a predefined sparse input name.
+This argument does not have a default value.
+You must specify a value.
 
-* `optimizer`: OptParamsPy, the optimizer dedicated to this sparse embedding layer. If the user does not specify the optimizer for the sparse embedding, it will adopt the same optimizer as dense layers.
+* `slot_size_array`: List[int], specify the maximum key value from each slot.
+It should be consistent with that of the sparse input.
+This parameter is used in `LocalizedSlotSparseEmbeddingHash` and `LocalizedSlotSparseEmbeddingOneHot`.
+The value you specify can help avoid wasting memory that is caused by an imbalanced vocabulary size.
+For more informtion, see [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array).
+This argument does not have a default value.
+You must specify a value.
+
+* `optimizer`: OptParamsPy, the optimizer that is dedicated to this sparse embedding layer.
+If you do not specify the optimizer for the sparse embedding, the sparse embedding layer adopts the same optimizer as dense layers.
 
 ## Embedding Types Detail
 ### DistributedSlotSparseEmbeddingHash Layer

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,7 @@ myst_enable_extensions = [
     "linkify",
     "replacements",
     "tasklist",
+    "dollarmath",
 ]
 myst_linkify_fuzzy_links = False
 myst_heading_anchors = 4


### PR DESCRIPTION
Previously, the documentation for the `slot_size_array`
argument indicated that customers should set the value to
the cardinality.

After this fix, the documentation indicates that
customers should specify the maximum key value for each
slot.