### PR TITLE
Add information about the slot_size_array argument

### DIFF
--- a/docs/source/api/hugectr_layer_book.md
+++ b/docs/source/api/hugectr_layer_book.md
@@ -52,21 +52,51 @@ hugectr.SparseEmbedding()
 `SparseEmbedding` specifies the parameters related to the sparse embedding layer. One or several `SparseEmbedding` layers should be added to the Model instance after `Input` and before `DenseLayer`.
 
 **Arguments**
-* `embedding_type`: The embedding type to be used. The supported types include `hugectr.Embedding_t.DistributedSlotSparseEmbeddingHash`, `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingHash` and `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingOneHot`. There is NO default value and it should be specified by users. For detail about different embedding types, please refer to [Embedding Types Detail](./hugectr_layer_book.md#embedding-types-detail).
+* `embedding_type`: The embedding type.
+Specify one of the following values:
+  * `hugectr.Embedding_t.DistributedSlotSparseEmbeddingHash`
+  * `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingHash`
+  * `hugectr.Embedding_t.LocalizedSlotSparseEmbeddingOneHot`
 
-* `workspace_size_per_gpu_in_mb`: Integer, the workspace memory size in megabyte per GPU. This workspace memory must be big enough to hold all the embedding vocabulary and its corresponding optimizer state used during the training and evaluation. There is NO default value and it should be specified by users. To understand how to set this value, please refer to [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array).
+  For information about the different embedding types, see [Embedding Types Detail](./hugectr_layer_book.md#embedding-types-detail).
+  This argument does not have a default value.
+  You must specify a value.
 
-* `embedding_vec_size`: Integer, the embedding vector size. There is NO default value and it should be specified by users.
+* `workspace_size_per_gpu_in_mb`: Integer, the workspace memory size in megabyte per GPU.
+This workspace memory must be big enough to hold all the embedding vocabulary and its corresponding optimizer state that is used during the training and evaluation.
+To understand how to set this value, see [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array).
+This argument does not have a default value.
+You must specify a value.
 
-* `combiner`: String, the intra-slot reduction operation, currently `sum` or `mean` are supported. There is NO default value and it should be specified by users.
+* `embedding_vec_size`: Integer, the embedding vector size.
+This argument does not have a default value.
+You must specify a value.
 
-* `sparse_embedding_name`: String, the name of the sparse embedding tensor to be referenced by following layers. There is NO default value and it should be specified by users.
+* `combiner`: String, the intra-slot reduction operation.
+Specify `sum` or `mean`.
+This argument does not have a default value.
+You must specify a value.
 
-* `bottom_name`: String, the number of the bottom tensor to be consumed by this sparse embedding layer. Please note that it should be a predefined sparse input name. There is NO default value and it should be specified by users.
+* `sparse_embedding_name`: String, the name of the sparse embedding tensor.
+This name is referenced by the following layers.
+This argument does not have a default value.
+You must specify a value.
 
-* `slot_size_array`: List[int], the cardinality array of input features. It should be consistent with that of the sparse input. This parameter is used in `LocalizedSlotSparseEmbeddingHash` and `LocalizedSlotSparseEmbeddingOneHot`, which can help avoid wasting memory caused by imbalance vocabulary size. Please refer [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array). There is NO default value and it should be specified by users.
+* `bottom_name`: String, the number of the bottom tensor to consume with this sparse embedding layer.
+Please note that the value should be a predefined sparse input name.
+This argument does not have a default value.
+You must specify a value.
 
-* `optimizer`: OptParamsPy, the optimizer dedicated to this sparse embedding layer. If the user does not specify the optimizer for the sparse embedding, it will adopt the same optimizer as dense layers.
+* `slot_size_array`: List[int], specify the maximum key value from each slot.
+It should be consistent with that of the sparse input.
+This parameter is used in `LocalizedSlotSparseEmbeddingHash` and `LocalizedSlotSparseEmbeddingOneHot`.
+The value you specify can help avoid wasting memory that is caused by an imbalanced vocabulary size.
+For more informtion, see [How to set workspace_size_per_gpu_in_mb and slot_size_array](../QAList.md#24-how-to-set-workspace_size_per_gpu_in_mb-and-slot_size_array).
+This argument does not have a default value.
+You must specify a value.
+
+* `optimizer`: OptParamsPy, the optimizer that is dedicated to this sparse embedding layer.
+If you do not specify the optimizer for the sparse embedding, the sparse embedding layer adopts the same optimizer as dense layers.
 
 ## Embedding Types Detail
 ### DistributedSlotSparseEmbeddingHash Layer

--- a/docs/source/api/python_interface.md
+++ b/docs/source/api/python_interface.md
@@ -200,29 +200,70 @@ hugectr.DataReaderParams()
 `DataReaderParams` specifies the parameters related to the data reader. HugeCTR currently supports three dataset formats, i.e., [Norm](#norm), [Raw](#raw) and [Parquet](#parquet). An `DataReaderParams` instance is required to initialize the `Model` instance.
 
 **Arguments**
-* `data_reader_type`: The type of the data reader which should be consistent with the dataset format. The supported types include `hugectr.DataReaderType_t.Norm`, `hugectr.DataReaderType_t.Raw` and `hugectr.DataReaderType_t.Parquet` and `DataReaderType_t.RawAsync`. The type `DataReaderType_t.RawAsync` is valid only if `is_dlrm` is set `True` within `CreateSolver`. There is NO default value and it should be specified by users.
+* `data_reader_type`: The type of the data reader which should be consistent with the dataset format.
+Specify one of the following types:
+  * `hugectr.DataReaderType_t.Norm`
+  * `hugectr.DataReaderType_t.Raw`
+  * `hugectr.DataReaderType_t.Parquet`
+  * `DataReaderType_t.RawAsync`
 
-* `source`: List[str] or String, the training dataset source. For Norm or Parquet dataset, it should be the file list of training data, e.g., `source = "file_list.txt"`. For Raw dataset, it should be a single training file, e.g., `source = "train_data.bin"`. When using embedding training cache, it can be specified with several file lists, e.g., `source = ["file_list.1.txt", "file_list.2.txt"]`. There is NO default value and it should be specified by users.
+  The type `DataReaderType_t.RawAsync` is valid only if `is_dlrm` is set `True` within `CreateSolver`.
+  This argument has no default value and you must specify a value.
 
-* `keyset`: List[str] or String, the keyset files. This argument will ONLY be valid when using embedding training cache and it should be corresponding to the `source`. For example, we can specify `source = ["file_list.1.txt", "file_list.2.txt"]` and `source = ["file_list.1.keyset", "file_list.2.keyset"]`, which have a one-to-one correspondence.
+* `source`: List[str] or String, the training dataset source.
+For Norm or Parquet dataset, specify the file list of training data, such as `source = "file_list.txt"`.
+For Raw dataset, specify a single training file, such as `source = "train_data.bin"`.
+When using the embedding training cache, you can specify several file lists, such as `source = ["file_list.1.txt", "file_list.2.txt"]`.
+This argument has no default value and you must specify a value.
 
-* `eval_source`: String, the evaluation dataset source. For Norm or Parquet dataset, it should be the file list of evaluation data. For Raw dataset, it should be a single evaluation file. There is NO default value and it should be specified by users.
+* `keyset`: List[str] or String, the keyset files.
+This argument is only valid when you use the embedding training cache.
+The value should correspond to the value for the `source` argument.
+For example, you can specify `source = ["file_list.1.txt", "file_list.2.txt"]` and `keyset = ["file_list.1.keyset", "file_list.2.keyset"]`
+The example shows the one-to-one correspondence between the `source` and `keyset` values.
 
-* `check_type`: The data error detection mechanism. The supported types include `hugectr.Check_t.Sum` (CheckSum) and `hugectr.Check_t.Non` (no detection). There is NO default value and it should be specified by users.
+* `eval_source`: String, the evaluation dataset source.
+For Norm or Parquet dataset, specify the file list of the evaluation data.
+For Raw dataset, specify a single evaluation file.
+This argument has no default value and you must specify a value.
 
-* `cache_eval_data`: Integer, the cache size of evaluation data on device, set this parameter greater than zero to restrict the memory that will be used. The default value is 0.
+* `check_type`: The data error detection mechanism.
+Specify `hugectr.Check_t.Sum` (CheckSum) or `hugectr.Check_t.Non` (no detection).
+This argument has no default value and you must specify a value.
 
-* `num_samples`: Integer, the number of samples in the traning dataset. This is ONLY valid for Raw dataset. The default value is 0.
+* `cache_eval_data`: Integer, the cache size of evaluation data on device.
+Specify a value that is greater than zero to restrict the memory use.
+The default value is 0.
 
-* `eval_num_samples`: Integer, the number of samples in the evaluation dataset. This is ONLY valid for Raw dataset. The default value is 0.
+* `num_samples`: Integer, the number of samples in the training dataset.
+This argument is valid for the Raw dataset format only.
+The default value is 0.
 
-* `float_label_dense`: Boolean, this is valid only for the Raw dataset format. If its value is set to `True`, the label and dense features for each sample are interpreted as float values. Otherwise, they are read as integer values while the dense features are preprocessed with log(dense[i] + 1.f). The default value is `True`.
+* `eval_num_samples`: Integer, the number of samples in the evaluation dataset.
+This argument is valid for the Raw dataset format only.
+The default value is 0.
 
-* `num_workers`: Integer, the number of data reader workers that concurrently load data. You can empirically decide the best one based on your dataset, training environment. The default value is 12.
+* `float_label_dense`: Boolean, this argument is valid for the Raw dataset format only.
+When set to `True`, the label and dense features for each sample are interpreted as float values.
+Otherwise, they are read as integer values while the dense features are preprocessed with $log(dense[i] + \text{1.f})$.
+The default value is `True`.
 
-* `slot_size_array`: List[int], the cardinality array of input features. It should be consistent with that of the sparse input. We requires this argument for Parquet format data and RawAsync format when you want to add offset to input key. The default value is an empty list.
+* `num_workers`: Integer, the number of data reader workers to load data concurrently.
+You can empirically decide the best value based on your dataset and training environment.
+The default value is 12.
 
-* `async_param`: AsyncParam, the parameters for async raw data reader. This argument is restricted to MLPerf use.
+* `slot_size_array`: List[int], specify the maximum key value for each slot.
+Refer to the following equation.
+The array should be consistent with that of the sparse input.
+HugeCTR requires this argument for Parquet format data and RawAsync format when you want to add an offset to the input key.
+The default value is an empty list.
+
+  The following equation shows how to determine the values to specify:
+
+  $slot\_size\_array[k] = \max\limits_i slot^k_i + 1$
+
+* `async_param`: AsyncParam, the parameters for async raw data reader.
+This argument is restricted to MLPerf use.
 
 ### Dataset formats
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,7 @@ myst_enable_extensions = [
     "linkify",
     "replacements",
     "tasklist",
+    "dollarmath",
 ]
 myst_linkify_fuzzy_links = False
 myst_heading_anchors = 4


### PR DESCRIPTION
Previously, the documentation for the `slot_size_array`
argument indicated that customers should set the value to
the cardinality.

After this fix, the documentation indicates that
customers should specify the maximum key value for each
slot.